### PR TITLE
Minor changes to work with SIMDe

### DIFF
--- a/dozeu.h
+++ b/dozeu.h
@@ -118,12 +118,7 @@ unittest() { debug("hello"); }
 #ifndef __x86_64__
 #  error "x86_64 is required"
 #endif
-#ifndef __SSE4_1__
-#  warning "SSE4.1 is automatically enabled in dozeu.h, please check compatibility to the system."
-#  define __dz_vectorize			__attribute__(( target( "sse4.1" ) ))
-#else
-#  define __dz_vectorize			/* follow the compiler options */
-#endif
+#define __dz_vectorize			/* follow the compiler options */
 
 /* inlining (FIXME: add appropriate __force_inline flag) */
 #define __dz_force_inline			inline
@@ -146,11 +141,7 @@ unittest() { debug("hello"); }
 #define dz_rm_ofs(_x)				( (int16_t)((uint16_t)(_x) ^ (uint16_t)0x8000) )
 
 
-#ifdef __SSE4_1__
-#  define dz_is_all_zero(x)			( _mm_test_all_zeros((x), (x)) == 1 )
-#else
-// #  define dz_is_all_zero(x)			( _mm_movemask_epi8((x)) == 0 )
-#endif
+#define dz_is_all_zero(x)			( _mm_test_all_zeros((x), (x)) == 1 )
 
 #define DZ_MEM_MARGIN_SIZE			( 256 )
 #define DZ_MEM_ALIGN_SIZE			( 16 )

--- a/dozeu.h
+++ b/dozeu.h
@@ -42,7 +42,15 @@ extern "C" {
 #include <stdint.h>
 #include <stddef.h>
 #include <string.h>
+
+/* _MM_FROUND_CUR_DIRECTION is defined in smmintrin.h (the include
+   file for SSE4.1), so if it's already defined we assume that the
+   SSE4.1 API is available and we can skip including <smmintrin.h>.
+   This allows Dozeu to use alternative implementations (e.g.,
+   <https://github.com/nemequ/simde>) without depending on them. */
+#if !defined(_MM_FROUND_CUR_DIRECTION)
 #include <smmintrin.h>
+#endif
 
 #ifndef DZ_CIGAR_OP
 #  define DZ_CIGAR_OP				0x04030201

--- a/dozeu.h
+++ b/dozeu.h
@@ -42,7 +42,7 @@ extern "C" {
 #include <stdint.h>
 #include <stddef.h>
 #include <string.h>
-#include <x86intrin.h>
+#include <smmintrin.h>
 
 #ifndef DZ_CIGAR_OP
 #  define DZ_CIGAR_OP				0x04030201


### PR DESCRIPTION
I'm trying to get Dozeu working on other architectures as well as x86 CPUs without SSE4.1, and a couple of minor changes were necessary.

The sse4.1 target attribute was a problem, of course.  You lose the warning for people using the wrong compiler flags, but I think it's worth the portability benefits.

Using <smmintrin.h> instead of <x86intrin.h> isn't strictly required, but it's a lot more portable.

I also removed the conditional definition of dz_is_all_zero since it wasn't doing any good but breaks things if `__SSE4_1__` isn't defined.

I also wanted to ask if you'd be willing to accept a patch to add [Hedley](https://github.com/nemequ/hedley), which provides portable versions for a lot of your macros.  If you don't want a copy of Hedley in the repository (it's a single header, public domain) I could also keep the current macros and only use Hedley if it's included before dozeu.h.  That said, I'd really like to take advantage of Hedley for a lot of stuff you don't currently have macros for and just assume GCC/x86, so if you're okay with adding a copy of Hedley to this repo I'd prefer to do that.

If I can use Hedley I should be able to make this work on pretty much any compiler, and with this PR merged you can already use SIMDe to compile on pretty much any architecture (just define `SIMDE_ENABLE_NATIVE_ALIASES` and include the sse4.1.h from SIMDe before including dozeu.h).